### PR TITLE
Improve security by replacing sprintf with snprintf to prevent buffer overflows

### DIFF
--- a/dynadjust/include/measurement_types/dnaangle.cpp
+++ b/dynadjust/include/measurement_types/dnaangle.cpp
@@ -275,7 +275,7 @@ void CDnaAngle::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex) c
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnacoordinate.cpp
+++ b/dynadjust/include/measurement_types/dnacoordinate.cpp
@@ -226,7 +226,7 @@ void CDnaCoordinate::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrInd
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnadirection.cpp
+++ b/dynadjust/include/measurement_types/dnadirection.cpp
@@ -633,7 +633,7 @@ void CDnaDirection::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrInde
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnadirectionset.cpp
+++ b/dynadjust/include/measurement_types/dnadirectionset.cpp
@@ -444,7 +444,7 @@ void CDnaDirectionSet::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrI
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 

--- a/dynadjust/include/measurement_types/dnadistance.cpp
+++ b/dynadjust/include/measurement_types/dnadistance.cpp
@@ -310,7 +310,7 @@ void CDnaDistance::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnagpsbaseline.cpp
+++ b/dynadjust/include/measurement_types/dnagpsbaseline.cpp
@@ -432,8 +432,8 @@ void CDnaGpsBaseline::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIn
 	measRecord.scale3 = m_dHscale;
 	measRecord.scale4 = m_dVscale;
 
-	sprintf(measRecord.epsgCode, "%s", m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epsgCode, sizeof(measRecord.epsgCode), "%s", m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	// X
 	measRecord.measAdj = m_measAdj;

--- a/dynadjust/include/measurement_types/dnagpspoint.cpp
+++ b/dynadjust/include/measurement_types/dnagpspoint.cpp
@@ -543,8 +543,8 @@ void CDnaGpsPoint::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex
 	measRecord.scale3 = m_dHscale;
 	measRecord.scale4 = m_dVscale;
 
-	sprintf(measRecord.epsgCode, "%s", m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epsgCode, sizeof(measRecord.epsgCode), "%s", m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	// X
 	measRecord.measAdj = m_measAdj;

--- a/dynadjust/include/measurement_types/dnaheight.cpp
+++ b/dynadjust/include/measurement_types/dnaheight.cpp
@@ -210,7 +210,7 @@ void CDnaHeight::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex) 
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnaheightdifference.cpp
+++ b/dynadjust/include/measurement_types/dnaheightdifference.cpp
@@ -245,7 +245,7 @@ void CDnaHeightDifference::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 
 	measRecord.measurementStations = m_MSmeasurementStations;
 	measRecord.fileOrder = ((*msrIndex)++);
 
-	sprintf(measRecord.epoch, "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnameasurement.cpp
+++ b/dynadjust/include/measurement_types/dnameasurement.cpp
@@ -232,8 +232,8 @@ void CDnaCovariance::WriteBinaryMsr(std::ofstream *binary_stream, PUINT32 msrInd
 	measRecord.station2 = m_lstn2Index;	
 	measRecord.clusterID = m_lclusterID;
 	
-	sprintf(measRecord.epsgCode, "%s", epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
-	sprintf(measRecord.epoch, "%s", epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.epsgCode, sizeof(measRecord.epsgCode), "%s", epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
+	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	// X
 	measRecord.measStart = xCov;

--- a/dynadjust/include/measurement_types/dnameasurement.hpp
+++ b/dynadjust/include/measurement_types/dnameasurement.hpp
@@ -140,7 +140,7 @@ typedef struct msr_t {
 			memset(coordType, '\0', sizeof(coordType));
 			// GDA94, lat, long, height
 			memset(epsgCode, '\0', sizeof(epsgCode));
-			sprintf(epsgCode, DEFAULT_EPSG_S);
+			snprintf(epsgCode, sizeof(epsgCode), DEFAULT_EPSG_S);
 			memset(epoch, '\0', sizeof(epoch));
 	}
 

--- a/dynadjust/include/measurement_types/dnastation.cpp
+++ b/dynadjust/include/measurement_types/dnastation.cpp
@@ -935,7 +935,7 @@ void CDnaStation::SetStationRec(const station_t& stationRecord)
 	else
 		m_strHemisphereZone = "N";
 	char zone[3];
-	sprintf(zone, "%d", m_zone);
+	snprintf(zone, sizeof(zone), "%d", m_zone);
 	m_strHemisphereZone += zone;
 	SetDescription(stationRecord.description);
 	m_lfileOrder = stationRecord.fileOrder;

--- a/dynadjust/include/parameters/dnadatum.cpp
+++ b/dynadjust/include/parameters/dnadatum.cpp
@@ -135,7 +135,7 @@ std::string CDnaDatum::GetEpoch_s() const
 std::string CDnaDatum::GetEpsgCode_s() const 
 {
 	char epsgCode[8];
-	sprintf(epsgCode, "%d", epsgCode_);
+	snprintf(epsgCode, sizeof(epsgCode), "%d", epsgCode_);
 	return std::string(epsgCode); 
 }
 


### PR DESCRIPTION
Improve security by replacing sprintf with snprintf to prevent buffer overflows